### PR TITLE
travis: use docker-based service; opam: minor changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,16 @@
+language: c
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-docker.sh
+script: bash -ex .travis-docker.sh
+sudo: false
+services:
+  - docker
 env:
   global:
     - PACKAGE="pf"
+    - DISTRO="alpine"
   matrix:
     - OCAML_VERSION=4.07
     - OCAML_VERSION=4.08
     - OCAML_VERSION=4.09
-
-os:
-  - linux
-  - osx
-language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-opam.sh
-sudo: required
-script: bash -ex .travis-opam.sh
-branches:
-  only:
-    - gh-pages
-    - /.*/
-git:
-  depth: 2
 notifications:
   email: false

--- a/pf.opam
+++ b/pf.opam
@@ -24,4 +24,5 @@ depends: [
   "rresult"   { >= "0.5.0" }
   "uri"       { >= "1.9.5" }
   "ipaddr"    { >= "4.0.0"  }
+  "alcotest" {with-test}
 ]

--- a/pf.opam
+++ b/pf.opam
@@ -11,12 +11,12 @@ tags: "org:mirage"
 build: [
   [ "dune" "subst"] {pinned}
   [ "dune" "build" "-p" name "-j" jobs ]
+  [ "dune" "runtest" "-p" name "-j" jobs ] {with-test}
 ]
 
 depends: [
-  "ocamlfind" {build}
-  "dune"  {build & >= "1.0"}
-  "ocaml" {build & >= "4.07.0" }
+  "dune"  {>= "1.0"}
+  "ocaml" {>= "4.07.0" }
   "cstruct"   { >= "3.2.0"  }
   "angstrom"  { >= "0.7.0"  }
   "fmt"       { >= "0.8.4"  }


### PR DESCRIPTION
these are minor changes for travis (use docker), and the opam file (run tests).

on my laptop, I get:
```
-- Primitives.000 [address: IPv6.] Failed --
in /usr/home/hannes/devel/mirage/ocaml-pf/_build/default/test/_build/_tests/20FB707D-AD49-4F21-93B1-45B980113E74/Primitives.000.output:
--------------------------------------------------------------------------------
ASSERT IS-OK fe80::123
--------------------------------------------------------------------------------
--------------------------------------------------------------------------------
ASSERT Ipaddr.IPv6 not supporting zone ID
--------------------------------------------------------------------------------
Test error: Error Ipaddr.IPv6 not supporting zone ID.
Raised at file "src/alcotest.ml", line 668, characters 48-71
Called from file "test/alcotest_parse.ml", line 33, characters 22-72
Called from file "src/alcotest.ml", line 285, characters 8-14


The full test results are available in `/usr/home/hannes/devel/mirage/ocaml-pf/_build/default/test/_build/_tests/20FB707D-AD49-4F21-93B1-45B980113E74`.
1 error! in 0.006s. 8 tests run.
```

is this expected //cc @cfcs ?

this is aligned with #3 but targets master instead of the just-qubes branch